### PR TITLE
Autoloading + autogenerating of entity proxy classes

### DIFF
--- a/DependencyInjection/Neo4jExtension.php
+++ b/DependencyInjection/Neo4jExtension.php
@@ -33,14 +33,14 @@ class Neo4jExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
-	    $connectionServicesIds = $this->handleConnections( $config, $container );
-	    $container->setParameter( 'neo4j.connections', $connectionServicesIds );
+        $connectionServicesIds = $this->handleConnections($config, $container);
+        $container->setParameter('neo4j.connections', $connectionServicesIds);
         $clientServiceIds = $this->handleClients($config, $container);
 
         if ($this->validateEntityManagers($config)) {
             $loader->load('entity_manager.xml');
-	        $entityManagersIds = $this->handleEntityMangers( $config, $container, $clientServiceIds );
-	        $container->setParameter( 'neo4j.entity_managers', $entityManagersIds );
+            $entityManagersIds = $this->handleEntityMangers($config, $container, $clientServiceIds);
+            $container->setParameter('neo4j.entity_managers', $entityManagersIds);
             $container->setAlias('neo4j.entity_manager', 'neo4j.entity_manager.default');
         }
 
@@ -134,38 +134,39 @@ class Neo4jExtension extends Extension
     }
 
     /**
-     * @param array $config
+     * @param array            $config
      * @param ContainerBuilder $container
      *
      * @return array with service ids
      */
-    private function handleClients( array &$config, ContainerBuilder $container ): array {
-        if ( empty( $config['clients'] ) ) {
+    private function handleClients(array &$config, ContainerBuilder $container): array
+    {
+        if (empty($config['clients'])) {
             // Add default entity manager if none set.
-            $config['clients']['default'] = [ 'connections' => [ 'default' ] ];
+            $config['clients']['default'] = ['connections' => ['default']];
         }
 
         $serviceIds = [];
-        foreach ( $config['clients'] as $name => $data ) {
-            $connections         = [];
-            $serviceIds[ $name ] = $serviceId = sprintf( 'neo4j.client.%s', $name );
-            foreach ( $data['connections'] as $connectionName ) {
-                if ( empty( $config['connections'][ $connectionName ] ) ) {
-                    throw new InvalidConfigurationException( sprintf(
+        foreach ($config['clients'] as $name => $data) {
+            $connections = [];
+            $serviceIds[$name] = $serviceId = sprintf('neo4j.client.%s', $name);
+            foreach ($data['connections'] as $connectionName) {
+                if (empty($config['connections'][$connectionName])) {
+                    throw new InvalidConfigurationException(sprintf(
                         'Client "%s" is configured to use connection named "%s" but there is no such connection',
                         $name,
                         $connectionName
-                    ) );
+                    ));
                 }
                 $connections[] = $connectionName;
             }
-            if ( empty( $connections ) ) {
+            if (empty($connections)) {
                 $connections[] = 'default';
             }
 
             $container
-                ->setDefinition( $serviceId, new DefinitionDecorator( 'neo4j.client.abstract' ) )
-                ->setArguments( [ $connections ] );
+                ->setDefinition($serviceId, new DefinitionDecorator('neo4j.client.abstract'))
+                ->setArguments([$connections]);
         }
 
         return $serviceIds;
@@ -198,32 +199,33 @@ class Neo4jExtension extends Extension
     }
 
     /**
-     * @param array $config
+     * @param array            $config
      * @param ContainerBuilder $container
-     * @param array $clientServiceIds
+     * @param array            $clientServiceIds
      *
      * @return array
      */
-    private function handleEntityMangers( array &$config, ContainerBuilder $container, array $clientServiceIds ): array {
+    private function handleEntityMangers(array &$config, ContainerBuilder $container, array $clientServiceIds): array
+    {
         $serviceIds = [];
-        foreach ( $config['entity_managers'] as $name => $data ) {
-            $serviceIds[] = $serviceId = sprintf( 'neo4j.entity_manager.%s', $name );
-            $clientName   = $data['client'];
-            if ( empty( $clientServiceIds[ $clientName ] ) ) {
-                throw new InvalidConfigurationException( sprintf(
+        foreach ($config['entity_managers'] as $name => $data) {
+            $serviceIds[] = $serviceId = sprintf('neo4j.entity_manager.%s', $name);
+            $clientName = $data['client'];
+            if (empty($clientServiceIds[$clientName])) {
+                throw new InvalidConfigurationException(sprintf(
                     'EntityManager "%s" is configured to use client named "%s" but there is no such client',
                     $name,
                     $clientName
-                ) );
+                ));
             }
-            $cacheDir = empty( $data['cache_dir'] ) ? $container->getParameter( 'kernel.cache_dir' ) . '/neo4j' : $data['cache_dir'];
-            $container->setParameter( 'neo4j.cache_dir', $cacheDir );
+            $cacheDir = empty($data['cache_dir']) ? $container->getParameter('kernel.cache_dir').'/neo4j' : $data['cache_dir'];
+            $container->setParameter('neo4j.cache_dir', $cacheDir);
             $container
-                ->setDefinition( $serviceId, new DefinitionDecorator( 'neo4j.entity_manager.abstract' ) )
-                ->setArguments( [
-                    $container->getDefinition( $clientServiceIds[ $clientName ] ),
+                ->setDefinition($serviceId, new DefinitionDecorator('neo4j.entity_manager.abstract'))
+                ->setArguments([
+                    $container->getDefinition($clientServiceIds[$clientName]),
                     $cacheDir,
-                ] );
+                ]);
         }
 
         return $serviceIds;
@@ -232,7 +234,8 @@ class Neo4jExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function getAlias(): string {
+    public function getAlias(): string
+    {
         return 'neo4j';
     }
 }

--- a/DependencyInjection/ProxyAutoloader.php
+++ b/DependencyInjection/ProxyAutoloader.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace Neo4j\Neo4jBundle\DependencyInjection;
 
@@ -10,32 +10,34 @@ namespace Neo4j\Neo4jBundle\DependencyInjection;
  * @author Dmitrii Shargorodskii <1337.um@gmail.com>
  * @author Benjamin Eberlei <kontakt@beberlei.de> - author of Doctrine (proxy) Autoloader
  */
-class ProxyAutoloader {
+class ProxyAutoloader
+{
     /**
      * Registers and returns autoloader callback for the given proxy dir and namespace.
      *
-     * @param string $proxyDir
-     * @param string $proxyNamespace
+     * @param string        $proxyDir
+     * @param string        $proxyNamespace
      * @param callable|null $notFoundCallback Invoked when the proxy file is not found.
      *
      * @return \Closure
      */
-    public static function register( $proxyDir, $proxyNamespace, $notFoundCallback = null ) {
-        $proxyNamespace = ltrim( $proxyNamespace, '\\' );
+    public static function register($proxyDir, $proxyNamespace, $notFoundCallback = null)
+    {
+        $proxyNamespace = ltrim($proxyNamespace, '\\');
 
-        $autoloader = function ( $className ) use ( $proxyDir, $proxyNamespace, $notFoundCallback ) {
-            if ( 0 === strpos( $className, $proxyNamespace ) ) {
-                $file = ProxyAutoloader::resolveFile( $proxyDir, $proxyNamespace, $className );
+        $autoloader = function ($className) use ($proxyDir, $proxyNamespace, $notFoundCallback) {
+            if (0 === strpos($className, $proxyNamespace)) {
+                $file = ProxyAutoloader::resolveFile($proxyDir, $proxyNamespace, $className);
 
-                if ( $notFoundCallback && ! file_exists( $file ) ) {
-                    call_user_func( $notFoundCallback, $proxyDir, $proxyNamespace, $className );
+                if ($notFoundCallback && !file_exists($file)) {
+                    call_user_func($notFoundCallback, $proxyDir, $proxyNamespace, $className);
                 }
 
                 require $file;
             }
         };
 
-        spl_autoload_register( $autoloader );
+        spl_autoload_register($autoloader);
 
         return $autoloader;
     }
@@ -52,12 +54,12 @@ class ProxyAutoloader {
      * @param string $className
      *
      * @return string
-     *
      */
-    public static function resolveFile( $proxyDir, $proxyPrefix, $className ) {
-        $proxyPrefix = ( strpos( $className, $proxyPrefix ) === 0 ) ? '' : $proxyPrefix;
-        $fileName    = $proxyPrefix . str_replace( '\\', '_', $className );
+    public static function resolveFile($proxyDir, $proxyPrefix, $className)
+    {
+        $proxyPrefix = (strpos($className, $proxyPrefix) === 0) ? '' : $proxyPrefix;
+        $fileName = $proxyPrefix.str_replace('\\', '_', $className);
 
-        return $proxyDir . DIRECTORY_SEPARATOR . $fileName . '.php';
+        return $proxyDir.DIRECTORY_SEPARATOR.$fileName.'.php';
     }
 }

--- a/DependencyInjection/ProxyAutoloader.php
+++ b/DependencyInjection/ProxyAutoloader.php
@@ -1,0 +1,63 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Neo4j\Neo4jBundle\DependencyInjection;
+
+/**
+ * Special Autoloader for Proxy classes, which are not PSR-0 compliant.
+ *
+ * @author Dmitrii Shargorodskii <1337.um@gmail.com>
+ * @author Benjamin Eberlei <kontakt@beberlei.de> - author of Doctrine (proxy) Autoloader
+ */
+class ProxyAutoloader {
+	/**
+	 * Registers and returns autoloader callback for the given proxy dir and namespace.
+	 *
+	 * @param string $proxyDir
+	 * @param string $proxyNamespace
+	 * @param callable|null $notFoundCallback Invoked when the proxy file is not found.
+	 *
+	 * @return \Closure
+	 */
+	public static function register( $proxyDir, $proxyNamespace, $notFoundCallback = null ) {
+		$proxyNamespace = ltrim( $proxyNamespace, '\\' );
+
+		$autoloader = function ( $className ) use ( $proxyDir, $proxyNamespace, $notFoundCallback ) {
+			if ( 0 === strpos( $className, $proxyNamespace ) ) {
+				$file = ProxyAutoloader::resolveFile( $proxyDir, $proxyNamespace, $className );
+
+				if ( $notFoundCallback && ! file_exists( $file ) ) {
+					call_user_func( $notFoundCallback, $proxyDir, $proxyNamespace, $className );
+				}
+
+				require $file;
+			}
+		};
+
+		spl_autoload_register( $autoloader );
+
+		return $autoloader;
+	}
+
+	/**
+	 * Resolves proxy class name to a filename based on the following pattern.
+	 *
+	 * 1. if className has prefix already - do not add another prefix
+	 * 2. Remove namespace separators from remaining class name.
+	 * 3. Return PHP filename from proxy-dir with the result from 2.
+	 *
+	 * @param string $proxyDir
+	 * @param string $proxyPrefix
+	 * @param string $className
+	 *
+	 * @return string
+	 *
+	 */
+	public static function resolveFile( $proxyDir, $proxyPrefix, $className ) {
+		$proxyPrefix = ( strpos( $className, $proxyPrefix ) === 0 ) ? '' : $proxyPrefix;
+		$fileName    = $proxyPrefix . str_replace( '\\', '_', $className );
+
+		return $proxyDir . DIRECTORY_SEPARATOR . $fileName . '.php';
+	}
+}

--- a/DependencyInjection/ProxyAutoloader.php
+++ b/DependencyInjection/ProxyAutoloader.php
@@ -11,53 +11,53 @@ namespace Neo4j\Neo4jBundle\DependencyInjection;
  * @author Benjamin Eberlei <kontakt@beberlei.de> - author of Doctrine (proxy) Autoloader
  */
 class ProxyAutoloader {
-	/**
-	 * Registers and returns autoloader callback for the given proxy dir and namespace.
-	 *
-	 * @param string $proxyDir
-	 * @param string $proxyNamespace
-	 * @param callable|null $notFoundCallback Invoked when the proxy file is not found.
-	 *
-	 * @return \Closure
-	 */
-	public static function register( $proxyDir, $proxyNamespace, $notFoundCallback = null ) {
-		$proxyNamespace = ltrim( $proxyNamespace, '\\' );
+    /**
+     * Registers and returns autoloader callback for the given proxy dir and namespace.
+     *
+     * @param string $proxyDir
+     * @param string $proxyNamespace
+     * @param callable|null $notFoundCallback Invoked when the proxy file is not found.
+     *
+     * @return \Closure
+     */
+    public static function register( $proxyDir, $proxyNamespace, $notFoundCallback = null ) {
+        $proxyNamespace = ltrim( $proxyNamespace, '\\' );
 
-		$autoloader = function ( $className ) use ( $proxyDir, $proxyNamespace, $notFoundCallback ) {
-			if ( 0 === strpos( $className, $proxyNamespace ) ) {
-				$file = ProxyAutoloader::resolveFile( $proxyDir, $proxyNamespace, $className );
+        $autoloader = function ( $className ) use ( $proxyDir, $proxyNamespace, $notFoundCallback ) {
+            if ( 0 === strpos( $className, $proxyNamespace ) ) {
+                $file = ProxyAutoloader::resolveFile( $proxyDir, $proxyNamespace, $className );
 
-				if ( $notFoundCallback && ! file_exists( $file ) ) {
-					call_user_func( $notFoundCallback, $proxyDir, $proxyNamespace, $className );
-				}
+                if ( $notFoundCallback && ! file_exists( $file ) ) {
+                    call_user_func( $notFoundCallback, $proxyDir, $proxyNamespace, $className );
+                }
 
-				require $file;
-			}
-		};
+                require $file;
+            }
+        };
 
-		spl_autoload_register( $autoloader );
+        spl_autoload_register( $autoloader );
 
-		return $autoloader;
-	}
+        return $autoloader;
+    }
 
-	/**
-	 * Resolves proxy class name to a filename based on the following pattern.
-	 *
-	 * 1. if className has prefix already - do not add another prefix
-	 * 2. Remove namespace separators from remaining class name.
-	 * 3. Return PHP filename from proxy-dir with the result from 2.
-	 *
-	 * @param string $proxyDir
-	 * @param string $proxyPrefix
-	 * @param string $className
-	 *
-	 * @return string
-	 *
-	 */
-	public static function resolveFile( $proxyDir, $proxyPrefix, $className ) {
-		$proxyPrefix = ( strpos( $className, $proxyPrefix ) === 0 ) ? '' : $proxyPrefix;
-		$fileName    = $proxyPrefix . str_replace( '\\', '_', $className );
+    /**
+     * Resolves proxy class name to a filename based on the following pattern.
+     *
+     * 1. if className has prefix already - do not add another prefix
+     * 2. Remove namespace separators from remaining class name.
+     * 3. Return PHP filename from proxy-dir with the result from 2.
+     *
+     * @param string $proxyDir
+     * @param string $proxyPrefix
+     * @param string $className
+     *
+     * @return string
+     *
+     */
+    public static function resolveFile( $proxyDir, $proxyPrefix, $className ) {
+        $proxyPrefix = ( strpos( $className, $proxyPrefix ) === 0 ) ? '' : $proxyPrefix;
+        $fileName    = $proxyPrefix . str_replace( '\\', '_', $className );
 
-		return $proxyDir . DIRECTORY_SEPARATOR . $fileName . '.php';
-	}
+        return $proxyDir . DIRECTORY_SEPARATOR . $fileName . '.php';
+    }
 }

--- a/Factory/ClientFactory.php
+++ b/Factory/ClientFactory.php
@@ -37,7 +37,7 @@ final class ClientFactory
     /**
      * Build an Client form multiple connection.
      *
-     * @param string $names
+     * @param array $names
      *
      * @return ClientInterface
      */

--- a/Neo4jBundle.php
+++ b/Neo4jBundle.php
@@ -2,16 +2,90 @@
 
 namespace Neo4j\Neo4jBundle;
 
+use GraphAware\Bolt\Result\Type\Node;
+use GraphAware\Neo4j\OGM\EntityManager;
+use GraphAware\Neo4j\OGM\Metadata\Factory\Annotation\AnnotationGraphEntityMetadataFactory;
+use GraphAware\Neo4j\OGM\Proxy\ProxyFactory;
 use Neo4j\Neo4jBundle\DependencyInjection\Neo4jExtension;
+use Neo4j\Neo4jBundle\DependencyInjection\ProxyAutoloader;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class Neo4jBundle extends Bundle
-{
-    public function getContainerExtension()
-    {
-        return new Neo4jExtension();
-    }
+class Neo4jBundle extends Bundle {
+
+	private $autoloader;
+
+	/**
+	 * Boots the Bundle.
+	 * Registers class autoloder for cached/uncached proxy entity classes
+	 */
+	public function boot() {
+
+		// See https://github.com/symfony/symfony/pull/3419 for usage of references
+		$container = &$this->container;
+
+		// generates proxy classes if autoloader cant find one in cache
+		$proxyGenerator = function ( $proxyDir, $proxyPrefix, $className ) use ( &$container ) {
+
+			$originalClassName = str_replace( '_', '\\', substr( $className, strlen( $proxyPrefix ) ) );
+			/** @var $registry Registry */
+			$registry = $container->get( 'neo4j.entity_managers_registry' );
+
+			// iterates through all entity managers to auto-generate desired proxy file
+			/** @var $em EntityManager */
+			foreach ( $registry->getManagers() as $em ) {
+
+				/** @var AnnotationGraphEntityMetadataFactory $metadataFactory */
+				$metadataFactory = $em->getMetadataFactory();
+
+				$classMetadata = $metadataFactory->create( $originalClassName );
+				$proxyFactory  = new ProxyFactory( $em, $classMetadata );
+				//line below must be replaced with $proxyFactory->createProxy(); when createProxy() method will be public
+				$proxyFactory->fromNode( new Node( - 1 ) );
+
+				clearstatcache( true, ProxyAutoloader::resolveFile( $em->getProxyDirectory(), $proxyPrefix, $originalClassName ) );
+				break;
+			}
+		};
+
+		$this->autoloader = ProxyAutoloader::register( $container->getParameter( 'neo4j.cache_dir' ), 'neo4j_ogm_proxy_', $proxyGenerator );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function shutdown() {
+
+
+		if ( null !== $this->autoloader ) {
+			spl_autoload_unregister( $this->autoloader );
+			$this->autoloader = null;
+		}
+
+		// Clear all entity managers to clear references to entities for GC
+		if ( $this->container->hasParameter( 'neo4j.entity_managers' ) ) {
+			foreach ( $this->container->getParameter( 'neo4j.entity_managers' ) as $id ) {
+				if ( $this->container->initialized( $id ) ) {
+					$this->container->get( $id )->clear();
+				}
+			}
+		}
+
+		// Close all connections to avoid reaching too many connections in the process when booting again later (tests)
+		if ( $this->container->hasParameter( 'neo4j.connections' ) ) {
+			foreach ( $this->container->getParameter( 'neo4j.connections' ) as $id ) {
+				if ( $this->container->initialized( $id ) ) {
+					//@todo: this line will create new session if current session isn`t started, then close it.
+					$this->container->get( $id )->getSession()->close();
+				}
+			}
+		}
+
+	}
+
+	public function getContainerExtension() {
+		return new Neo4jExtension();
+	}
 }

--- a/Neo4jBundle.php
+++ b/Neo4jBundle.php
@@ -13,81 +13,79 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class Neo4jBundle extends Bundle {
-
+class Neo4jBundle extends Bundle
+{
     private $autoloader;
 
     /**
      * Boots the Bundle.
-     * Registers class autoloder for cached/uncached proxy entity classes
+     * Registers class autoloder for cached/uncached proxy entity classes.
      */
-    public function boot() {
-
-        if ( $this->container->hasParameter( 'neo4j.cache_dir' ) ) {
+    public function boot()
+    {
+        if ($this->container->hasParameter('neo4j.cache_dir')) {
             // See https://github.com/symfony/symfony/pull/3419 for usage of references
             $container = &$this->container;
 
             // generates proxy classes if autoloader cant find one in cache
-            $proxyGenerator = function ( $proxyDir, $proxyPrefix, $className ) use ( &$container ) {
-
-                $originalClassName = str_replace( '_', '\\', substr( $className, strlen( $proxyPrefix ) ) );
+            $proxyGenerator = function ($proxyDir, $proxyPrefix, $className) use (&$container) {
+                $originalClassName = str_replace('_', '\\', substr($className, strlen($proxyPrefix)));
                 /** @var $registry Registry */
-                $registry = $container->get( 'neo4j.entity_managers_registry' );
+                $registry = $container->get('neo4j.entity_managers_registry');
 
                 // iterates through all entity managers to auto-generate desired proxy file
                 /** @var $em EntityManager */
-                foreach ( $registry->getManagers() as $em ) {
-
+                foreach ($registry->getManagers() as $em) {
                     /** @var AnnotationGraphEntityMetadataFactory $metadataFactory */
                     $metadataFactory = $em->getMetadataFactory();
 
-                    $classMetadata = $metadataFactory->create( $originalClassName );
-                    $proxyFactory  = new ProxyFactory( $em, $classMetadata );
+                    $classMetadata = $metadataFactory->create($originalClassName);
+                    $proxyFactory = new ProxyFactory($em, $classMetadata);
                     //@todo: line below must be replaced with $proxyFactory->createProxy(); when createProxy() method will be public
-                    $proxyFactory->fromNode( new Node( - 1 ) );
+                    $proxyFactory->fromNode(new Node(-1));
 
-                    clearstatcache( true, ProxyAutoloader::resolveFile( $em->getProxyDirectory(), $proxyPrefix, $originalClassName ) );
+                    clearstatcache(true, ProxyAutoloader::resolveFile($em->getProxyDirectory(), $proxyPrefix, $originalClassName));
+
                     break;
                 }
             };
 
-            $this->autoloader = ProxyAutoloader::register( $container->getParameter( 'neo4j.cache_dir' ), 'neo4j_ogm_proxy_', $proxyGenerator );
+            $this->autoloader = ProxyAutoloader::register($container->getParameter('neo4j.cache_dir'), 'neo4j_ogm_proxy_', $proxyGenerator);
         }
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    public function shutdown() {
-
-
-        if ( null !== $this->autoloader ) {
-            spl_autoload_unregister( $this->autoloader );
+    public function shutdown()
+    {
+        if (null !== $this->autoloader) {
+            spl_autoload_unregister($this->autoloader);
             $this->autoloader = null;
         }
 
         // Clear all entity managers to clear references to entities for GC
-        if ( $this->container->hasParameter( 'neo4j.entity_managers' ) ) {
-            foreach ( $this->container->getParameter( 'neo4j.entity_managers' ) as $id ) {
-                if ( $this->container->initialized( $id ) ) {
-                    $this->container->get( $id )->clear();
+        if ($this->container->hasParameter('neo4j.entity_managers')) {
+            foreach ($this->container->getParameter('neo4j.entity_managers') as $id) {
+                if ($this->container->initialized($id)) {
+                    $this->container->get($id)->clear();
                 }
             }
         }
 
         // Close all connections to avoid reaching too many connections in the process when booting again later (tests)
-        if ( $this->container->hasParameter( 'neo4j.connections' ) ) {
-            foreach ( $this->container->getParameter( 'neo4j.connections' ) as $id ) {
-                if ( $this->container->initialized( $id ) ) {
+        if ($this->container->hasParameter('neo4j.connections')) {
+            foreach ($this->container->getParameter('neo4j.connections') as $id) {
+                if ($this->container->initialized($id)) {
                     //@todo: this line will create new session if current session isn`t started, then close it.
-                    $this->container->get( $id )->getSession()->close();
+                    $this->container->get($id)->getSession()->close();
                 }
             }
         }
-
     }
 
-    public function getContainerExtension() {
+    public function getContainerExtension()
+    {
         return new Neo4jExtension();
     }
 }

--- a/Neo4jBundle.php
+++ b/Neo4jBundle.php
@@ -15,79 +15,79 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class Neo4jBundle extends Bundle {
 
-	private $autoloader;
+    private $autoloader;
 
-	/**
-	 * Boots the Bundle.
-	 * Registers class autoloder for cached/uncached proxy entity classes
-	 */
-	public function boot() {
+    /**
+     * Boots the Bundle.
+     * Registers class autoloder for cached/uncached proxy entity classes
+     */
+    public function boot() {
 
-		if ( $this->container->hasParameter( 'neo4j.cache_dir' ) ) {
-			// See https://github.com/symfony/symfony/pull/3419 for usage of references
-			$container = &$this->container;
+        if ( $this->container->hasParameter( 'neo4j.cache_dir' ) ) {
+            // See https://github.com/symfony/symfony/pull/3419 for usage of references
+            $container = &$this->container;
 
-			// generates proxy classes if autoloader cant find one in cache
-			$proxyGenerator = function ( $proxyDir, $proxyPrefix, $className ) use ( &$container ) {
+            // generates proxy classes if autoloader cant find one in cache
+            $proxyGenerator = function ( $proxyDir, $proxyPrefix, $className ) use ( &$container ) {
 
-				$originalClassName = str_replace( '_', '\\', substr( $className, strlen( $proxyPrefix ) ) );
-				/** @var $registry Registry */
-				$registry = $container->get( 'neo4j.entity_managers_registry' );
+                $originalClassName = str_replace( '_', '\\', substr( $className, strlen( $proxyPrefix ) ) );
+                /** @var $registry Registry */
+                $registry = $container->get( 'neo4j.entity_managers_registry' );
 
-				// iterates through all entity managers to auto-generate desired proxy file
-				/** @var $em EntityManager */
-				foreach ( $registry->getManagers() as $em ) {
+                // iterates through all entity managers to auto-generate desired proxy file
+                /** @var $em EntityManager */
+                foreach ( $registry->getManagers() as $em ) {
 
-					/** @var AnnotationGraphEntityMetadataFactory $metadataFactory */
-					$metadataFactory = $em->getMetadataFactory();
+                    /** @var AnnotationGraphEntityMetadataFactory $metadataFactory */
+                    $metadataFactory = $em->getMetadataFactory();
 
-					$classMetadata = $metadataFactory->create( $originalClassName );
-					$proxyFactory  = new ProxyFactory( $em, $classMetadata );
-					//@todo: line below must be replaced with $proxyFactory->createProxy(); when createProxy() method will be public
-					$proxyFactory->fromNode( new Node( - 1 ) );
+                    $classMetadata = $metadataFactory->create( $originalClassName );
+                    $proxyFactory  = new ProxyFactory( $em, $classMetadata );
+                    //@todo: line below must be replaced with $proxyFactory->createProxy(); when createProxy() method will be public
+                    $proxyFactory->fromNode( new Node( - 1 ) );
 
-					clearstatcache( true, ProxyAutoloader::resolveFile( $em->getProxyDirectory(), $proxyPrefix, $originalClassName ) );
-					break;
-				}
-			};
+                    clearstatcache( true, ProxyAutoloader::resolveFile( $em->getProxyDirectory(), $proxyPrefix, $originalClassName ) );
+                    break;
+                }
+            };
 
-			$this->autoloader = ProxyAutoloader::register( $container->getParameter( 'neo4j.cache_dir' ), 'neo4j_ogm_proxy_', $proxyGenerator );
-		}
-	}
+            $this->autoloader = ProxyAutoloader::register( $container->getParameter( 'neo4j.cache_dir' ), 'neo4j_ogm_proxy_', $proxyGenerator );
+        }
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public function shutdown() {
+    /**
+     * {@inheritDoc}
+     */
+    public function shutdown() {
 
 
-		if ( null !== $this->autoloader ) {
-			spl_autoload_unregister( $this->autoloader );
-			$this->autoloader = null;
-		}
+        if ( null !== $this->autoloader ) {
+            spl_autoload_unregister( $this->autoloader );
+            $this->autoloader = null;
+        }
 
-		// Clear all entity managers to clear references to entities for GC
-		if ( $this->container->hasParameter( 'neo4j.entity_managers' ) ) {
-			foreach ( $this->container->getParameter( 'neo4j.entity_managers' ) as $id ) {
-				if ( $this->container->initialized( $id ) ) {
-					$this->container->get( $id )->clear();
-				}
-			}
-		}
+        // Clear all entity managers to clear references to entities for GC
+        if ( $this->container->hasParameter( 'neo4j.entity_managers' ) ) {
+            foreach ( $this->container->getParameter( 'neo4j.entity_managers' ) as $id ) {
+                if ( $this->container->initialized( $id ) ) {
+                    $this->container->get( $id )->clear();
+                }
+            }
+        }
 
-		// Close all connections to avoid reaching too many connections in the process when booting again later (tests)
-		if ( $this->container->hasParameter( 'neo4j.connections' ) ) {
-			foreach ( $this->container->getParameter( 'neo4j.connections' ) as $id ) {
-				if ( $this->container->initialized( $id ) ) {
-					//@todo: this line will create new session if current session isn`t started, then close it.
-					$this->container->get( $id )->getSession()->close();
-				}
-			}
-		}
+        // Close all connections to avoid reaching too many connections in the process when booting again later (tests)
+        if ( $this->container->hasParameter( 'neo4j.connections' ) ) {
+            foreach ( $this->container->getParameter( 'neo4j.connections' ) as $id ) {
+                if ( $this->container->initialized( $id ) ) {
+                    //@todo: this line will create new session if current session isn`t started, then close it.
+                    $this->container->get( $id )->getSession()->close();
+                }
+            }
+        }
 
-	}
+    }
 
-	public function getContainerExtension() {
-		return new Neo4jExtension();
-	}
+    public function getContainerExtension() {
+        return new Neo4jExtension();
+    }
 }

--- a/Registry.php
+++ b/Registry.php
@@ -18,11 +18,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * References all OGM connections and entity managers in a given Container.
- * Used mostly to get all entity managers in bundle`s ->boot() method
+ * Used mostly to get all entity managers in bundle`s ->boot() method.
  *
  * @author Dmitrii Shargorodskii <1337.um@gmail.com>
  */
-class Registry {
+class Registry
+{
     private $container;
 
     /**
@@ -49,32 +50,31 @@ class Registry {
      * Constructor.
      *
      * @param ContainerInterface $container
-     * @param array $connections
-     * @param array $entityManagers
+     * @param array              $connections
+     * @param array              $entityManagers
      * @param $defaultConnection
      * @param $defaultManager
      */
-    public function __construct( ContainerInterface $container, $connections, $entityManagers, $defaultConnection, $defaultManager ) {
-        $this->container         = &$container;
-        $this->connections       = $connections;
-        $this->managers          = $entityManagers;
+    public function __construct(ContainerInterface $container, $connections, $entityManagers, $defaultConnection, $defaultManager)
+    {
+        $this->container = &$container;
+        $this->connections = $connections;
+        $this->managers = $entityManagers;
         $this->defaultConnection = $defaultConnection;
-        $this->defaultManager    = $defaultManager;
+        $this->defaultManager = $defaultManager;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getConnection( $name = null ) {
-        if ( null === $name ) {
+    public function getConnection($name = null)
+    {
+        if (null === $name) {
             $name = $this->defaultConnection;
         }
 
-        if ( ! isset( $this->connections[ $name ] ) ) {
-            throw new \InvalidArgumentException( sprintf( 'Connection named "%s" does not exist.', $name ) );
+        if (!isset($this->connections[$name])) {
+            throw new \InvalidArgumentException(sprintf('Connection named "%s" does not exist.', $name));
         }
 
-        return $this->getService( $this->connections[ $name ] );
+        return $this->getService($this->connections[$name]);
     }
 
     /**
@@ -86,24 +86,21 @@ class Registry {
      *
      * @return object The instance of the given service.
      */
-    protected function getService( $name ) {
-        return $this->container->get( $name );
+    protected function getService($name)
+    {
+        return $this->container->get($name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getConnectionNames() {
+    public function getConnectionNames()
+    {
         return $this->connections;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getConnections() {
+    public function getConnections()
+    {
         $connections = [];
-        foreach ( $this->connections as $name => $id ) {
-            $connections[ $name ] = $this->getService( $id );
+        foreach ($this->connections as $name => $id) {
+            $connections[$name] = $this->getService($id);
         }
 
         return $connections;
@@ -114,40 +111,33 @@ class Registry {
      *
      * @return Registry
      */
-    public function setConnections( array $connections ): Registry {
+    public function setConnections(array $connections): Registry
+    {
         $this->connections = $connections;
 
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getDefaultConnectionName() {
+    public function getDefaultConnectionName()
+    {
         return $this->defaultConnection;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getDefaultManagerName() {
+    public function getDefaultManagerName()
+    {
         return $this->defaultManager;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getManagerNames() {
+    public function getManagerNames()
+    {
         return $this->managers;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getManagers() {
+    public function getManagers()
+    {
         $dms = [];
-        foreach ( $this->managers as $name => $id ) {
-            $dms[ $name ] = $this->getService( $id );
+        foreach ($this->managers as $name => $id) {
+            $dms[$name] = $this->getService($id);
         }
 
         return $dms;
@@ -158,53 +148,49 @@ class Registry {
      *
      * @return Registry
      */
-    public function setManagers( array $managers ): Registry {
+    public function setManagers(array $managers): Registry
+    {
         $this->managers = $managers;
 
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getRepository( $persistentObjectName, $persistentManagerName = null ) {
-        return $this->getManager( $persistentManagerName )->getRepository( $persistentObjectName );
+    public function getRepository($persistentObjectName, $persistentManagerName = null)
+    {
+        return $this->getManager($persistentManagerName)->getRepository($persistentObjectName);
     }
 
     /**
-     * {@inheritdoc}
-     *
      * @throws \InvalidArgumentException
      */
-    public function getManager( $name = null ) {
-        if ( null === $name ) {
+    public function getManager($name = null)
+    {
+        if (null === $name) {
             $name = $this->defaultManager;
         }
 
-        if ( ! isset( $this->managers[ $name ] ) ) {
-            throw new \InvalidArgumentException( sprintf( 'Manager named "%s" does not exist.', $name ) );
+        if (!isset($this->managers[$name])) {
+            throw new \InvalidArgumentException(sprintf('Manager named "%s" does not exist.', $name));
         }
 
-        return $this->getService( $this->managers[ $name ] );
+        return $this->getService($this->managers[$name]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function resetManager( $name = null ) {
-        if ( null === $name ) {
+    public function resetManager($name = null)
+    {
+        if (null === $name) {
             $name = $this->defaultManager;
         }
 
-        if ( ! isset( $this->managers[ $name ] ) ) {
-            throw new \InvalidArgumentException( sprintf( 'Manager named "%s" does not exist.', $name ) );
+        if (!isset($this->managers[$name])) {
+            throw new \InvalidArgumentException(sprintf('Manager named "%s" does not exist.', $name));
         }
 
         // force the creation of a new document manager
         // if the current one is closed
-        $this->resetService( $this->managers[ $name ] );
+        $this->resetService($this->managers[$name]);
 
-        return $this->getManager( $name );
+        return $this->getManager($name);
     }
 
     /**
@@ -213,10 +199,9 @@ class Registry {
      * A service in this context is connection or a manager instance.
      *
      * @param string $name The name of the service.
-     *
-     * @return void
      */
-    protected function resetService( $name ) {
+    protected function resetService($name)
+    {
         //@todo: implement service reset
     }
 
@@ -225,7 +210,8 @@ class Registry {
      *
      * @return Registry
      */
-    public function addConnection( $connection ): Registry {
+    public function addConnection($connection): Registry
+    {
         $this->connections[] = $connection;
 
         return $this;
@@ -236,7 +222,8 @@ class Registry {
      *
      * @return Registry
      */
-    public function addManager( string $manager ): Registry {
+    public function addManager(string $manager): Registry
+    {
         $this->managers = $manager;
 
         return $this;

--- a/Registry.php
+++ b/Registry.php
@@ -23,222 +23,222 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @author Dmitrii Shargorodskii <1337.um@gmail.com>
  */
 class Registry {
-	private $container;
+    private $container;
 
-	/**
-	 * @var array
-	 */
-	private $connections;
+    /**
+     * @var array
+     */
+    private $connections;
 
-	/**
-	 * @var array
-	 */
-	private $managers;
+    /**
+     * @var array
+     */
+    private $managers;
 
-	/**
-	 * @var string
-	 */
-	private $defaultConnection;
+    /**
+     * @var string
+     */
+    private $defaultConnection;
 
-	/**
-	 * @var string
-	 */
-	private $defaultManager;
+    /**
+     * @var string
+     */
+    private $defaultManager;
 
-	/**
-	 * Constructor.
-	 *
-	 * @param ContainerInterface $container
-	 * @param array $connections
-	 * @param array $entityManagers
-	 * @param $defaultConnection
-	 * @param $defaultManager
-	 */
-	public function __construct( ContainerInterface $container, $connections, $entityManagers, $defaultConnection, $defaultManager ) {
-		$this->container         = &$container;
-		$this->connections       = $connections;
-		$this->managers          = $entityManagers;
-		$this->defaultConnection = $defaultConnection;
-		$this->defaultManager    = $defaultManager;
-	}
+    /**
+     * Constructor.
+     *
+     * @param ContainerInterface $container
+     * @param array $connections
+     * @param array $entityManagers
+     * @param $defaultConnection
+     * @param $defaultManager
+     */
+    public function __construct( ContainerInterface $container, $connections, $entityManagers, $defaultConnection, $defaultManager ) {
+        $this->container         = &$container;
+        $this->connections       = $connections;
+        $this->managers          = $entityManagers;
+        $this->defaultConnection = $defaultConnection;
+        $this->defaultManager    = $defaultManager;
+    }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getConnection( $name = null ) {
-		if ( null === $name ) {
-			$name = $this->defaultConnection;
-		}
+    /**
+     * {@inheritdoc}
+     */
+    public function getConnection( $name = null ) {
+        if ( null === $name ) {
+            $name = $this->defaultConnection;
+        }
 
-		if ( ! isset( $this->connections[ $name ] ) ) {
-			throw new \InvalidArgumentException( sprintf( 'Connection named "%s" does not exist.', $name ) );
-		}
+        if ( ! isset( $this->connections[ $name ] ) ) {
+            throw new \InvalidArgumentException( sprintf( 'Connection named "%s" does not exist.', $name ) );
+        }
 
-		return $this->getService( $this->connections[ $name ] );
-	}
+        return $this->getService( $this->connections[ $name ] );
+    }
 
-	/**
-	 * Fetches/creates the given services.
-	 *
-	 * A service in this context is connection or a manager instance.
-	 *
-	 * @param string $name The name of the service.
-	 *
-	 * @return object The instance of the given service.
-	 */
-	protected function getService( $name ) {
-		return $this->container->get( $name );
-	}
+    /**
+     * Fetches/creates the given services.
+     *
+     * A service in this context is connection or a manager instance.
+     *
+     * @param string $name The name of the service.
+     *
+     * @return object The instance of the given service.
+     */
+    protected function getService( $name ) {
+        return $this->container->get( $name );
+    }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getConnectionNames() {
-		return $this->connections;
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getConnectionNames() {
+        return $this->connections;
+    }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getConnections() {
-		$connections = [];
-		foreach ( $this->connections as $name => $id ) {
-			$connections[ $name ] = $this->getService( $id );
-		}
+    /**
+     * {@inheritdoc}
+     */
+    public function getConnections() {
+        $connections = [];
+        foreach ( $this->connections as $name => $id ) {
+            $connections[ $name ] = $this->getService( $id );
+        }
 
-		return $connections;
-	}
+        return $connections;
+    }
 
-	/**
-	 * @param array $connections
-	 *
-	 * @return Registry
-	 */
-	public function setConnections( array $connections ): Registry {
-		$this->connections = $connections;
+    /**
+     * @param array $connections
+     *
+     * @return Registry
+     */
+    public function setConnections( array $connections ): Registry {
+        $this->connections = $connections;
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getDefaultConnectionName() {
-		return $this->defaultConnection;
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultConnectionName() {
+        return $this->defaultConnection;
+    }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getDefaultManagerName() {
-		return $this->defaultManager;
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultManagerName() {
+        return $this->defaultManager;
+    }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getManagerNames() {
-		return $this->managers;
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getManagerNames() {
+        return $this->managers;
+    }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getManagers() {
-		$dms = [];
-		foreach ( $this->managers as $name => $id ) {
-			$dms[ $name ] = $this->getService( $id );
-		}
+    /**
+     * {@inheritdoc}
+     */
+    public function getManagers() {
+        $dms = [];
+        foreach ( $this->managers as $name => $id ) {
+            $dms[ $name ] = $this->getService( $id );
+        }
 
-		return $dms;
-	}
+        return $dms;
+    }
 
-	/**
-	 * @param array $managers
-	 *
-	 * @return Registry
-	 */
-	public function setManagers( array $managers ): Registry {
-		$this->managers = $managers;
+    /**
+     * @param array $managers
+     *
+     * @return Registry
+     */
+    public function setManagers( array $managers ): Registry {
+        $this->managers = $managers;
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getRepository( $persistentObjectName, $persistentManagerName = null ) {
-		return $this->getManager( $persistentManagerName )->getRepository( $persistentObjectName );
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getRepository( $persistentObjectName, $persistentManagerName = null ) {
+        return $this->getManager( $persistentManagerName )->getRepository( $persistentObjectName );
+    }
 
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @throws \InvalidArgumentException
-	 */
-	public function getManager( $name = null ) {
-		if ( null === $name ) {
-			$name = $this->defaultManager;
-		}
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function getManager( $name = null ) {
+        if ( null === $name ) {
+            $name = $this->defaultManager;
+        }
 
-		if ( ! isset( $this->managers[ $name ] ) ) {
-			throw new \InvalidArgumentException( sprintf( 'Manager named "%s" does not exist.', $name ) );
-		}
+        if ( ! isset( $this->managers[ $name ] ) ) {
+            throw new \InvalidArgumentException( sprintf( 'Manager named "%s" does not exist.', $name ) );
+        }
 
-		return $this->getService( $this->managers[ $name ] );
-	}
+        return $this->getService( $this->managers[ $name ] );
+    }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function resetManager( $name = null ) {
-		if ( null === $name ) {
-			$name = $this->defaultManager;
-		}
+    /**
+     * {@inheritdoc}
+     */
+    public function resetManager( $name = null ) {
+        if ( null === $name ) {
+            $name = $this->defaultManager;
+        }
 
-		if ( ! isset( $this->managers[ $name ] ) ) {
-			throw new \InvalidArgumentException( sprintf( 'Manager named "%s" does not exist.', $name ) );
-		}
+        if ( ! isset( $this->managers[ $name ] ) ) {
+            throw new \InvalidArgumentException( sprintf( 'Manager named "%s" does not exist.', $name ) );
+        }
 
-		// force the creation of a new document manager
-		// if the current one is closed
-		$this->resetService( $this->managers[ $name ] );
+        // force the creation of a new document manager
+        // if the current one is closed
+        $this->resetService( $this->managers[ $name ] );
 
-		return $this->getManager( $name );
-	}
+        return $this->getManager( $name );
+    }
 
-	/**
-	 * Resets the given services.
-	 *
-	 * A service in this context is connection or a manager instance.
-	 *
-	 * @param string $name The name of the service.
-	 *
-	 * @return void
-	 */
-	protected function resetService( $name ) {
-		//@todo: implement service reset
-	}
+    /**
+     * Resets the given services.
+     *
+     * A service in this context is connection or a manager instance.
+     *
+     * @param string $name The name of the service.
+     *
+     * @return void
+     */
+    protected function resetService( $name ) {
+        //@todo: implement service reset
+    }
 
-	/**
-	 * @param $connection
-	 *
-	 * @return Registry
-	 */
-	public function addConnection( $connection ): Registry {
-		$this->connections[] = $connection;
+    /**
+     * @param $connection
+     *
+     * @return Registry
+     */
+    public function addConnection( $connection ): Registry {
+        $this->connections[] = $connection;
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * @param string $manager
-	 *
-	 * @return Registry
-	 */
-	public function addManager( string $manager ): Registry {
-		$this->managers = $manager;
+    /**
+     * @param string $manager
+     *
+     * @return Registry
+     */
+    public function addManager( string $manager ): Registry {
+        $this->managers = $manager;
 
-		return $this;
-	}
+        return $this;
+    }
 }

--- a/Registry.php
+++ b/Registry.php
@@ -1,0 +1,244 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Neo4j\Neo4jBundle;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * References all OGM connections and entity managers in a given Container.
+ * Used mostly to get all entity managers in bundle`s ->boot() method
+ *
+ * @author Dmitrii Shargorodskii <1337.um@gmail.com>
+ */
+class Registry {
+	private $container;
+
+	/**
+	 * @var array
+	 */
+	private $connections;
+
+	/**
+	 * @var array
+	 */
+	private $managers;
+
+	/**
+	 * @var string
+	 */
+	private $defaultConnection;
+
+	/**
+	 * @var string
+	 */
+	private $defaultManager;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ContainerInterface $container
+	 * @param array $connections
+	 * @param array $entityManagers
+	 * @param $defaultConnection
+	 * @param $defaultManager
+	 */
+	public function __construct( ContainerInterface $container, $connections, $entityManagers, $defaultConnection, $defaultManager ) {
+		$this->container         = &$container;
+		$this->connections       = $connections;
+		$this->managers          = $entityManagers;
+		$this->defaultConnection = $defaultConnection;
+		$this->defaultManager    = $defaultManager;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getConnection( $name = null ) {
+		if ( null === $name ) {
+			$name = $this->defaultConnection;
+		}
+
+		if ( ! isset( $this->connections[ $name ] ) ) {
+			throw new \InvalidArgumentException( sprintf( 'Connection named "%s" does not exist.', $name ) );
+		}
+
+		return $this->getService( $this->connections[ $name ] );
+	}
+
+	/**
+	 * Fetches/creates the given services.
+	 *
+	 * A service in this context is connection or a manager instance.
+	 *
+	 * @param string $name The name of the service.
+	 *
+	 * @return object The instance of the given service.
+	 */
+	protected function getService( $name ) {
+		return $this->container->get( $name );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getConnectionNames() {
+		return $this->connections;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getConnections() {
+		$connections = [];
+		foreach ( $this->connections as $name => $id ) {
+			$connections[ $name ] = $this->getService( $id );
+		}
+
+		return $connections;
+	}
+
+	/**
+	 * @param array $connections
+	 *
+	 * @return Registry
+	 */
+	public function setConnections( array $connections ): Registry {
+		$this->connections = $connections;
+
+		return $this;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getDefaultConnectionName() {
+		return $this->defaultConnection;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getDefaultManagerName() {
+		return $this->defaultManager;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getManagerNames() {
+		return $this->managers;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getManagers() {
+		$dms = [];
+		foreach ( $this->managers as $name => $id ) {
+			$dms[ $name ] = $this->getService( $id );
+		}
+
+		return $dms;
+	}
+
+	/**
+	 * @param array $managers
+	 *
+	 * @return Registry
+	 */
+	public function setManagers( array $managers ): Registry {
+		$this->managers = $managers;
+
+		return $this;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getRepository( $persistentObjectName, $persistentManagerName = null ) {
+		return $this->getManager( $persistentManagerName )->getRepository( $persistentObjectName );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @throws \InvalidArgumentException
+	 */
+	public function getManager( $name = null ) {
+		if ( null === $name ) {
+			$name = $this->defaultManager;
+		}
+
+		if ( ! isset( $this->managers[ $name ] ) ) {
+			throw new \InvalidArgumentException( sprintf( 'Manager named "%s" does not exist.', $name ) );
+		}
+
+		return $this->getService( $this->managers[ $name ] );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function resetManager( $name = null ) {
+		if ( null === $name ) {
+			$name = $this->defaultManager;
+		}
+
+		if ( ! isset( $this->managers[ $name ] ) ) {
+			throw new \InvalidArgumentException( sprintf( 'Manager named "%s" does not exist.', $name ) );
+		}
+
+		// force the creation of a new document manager
+		// if the current one is closed
+		$this->resetService( $this->managers[ $name ] );
+
+		return $this->getManager( $name );
+	}
+
+	/**
+	 * Resets the given services.
+	 *
+	 * A service in this context is connection or a manager instance.
+	 *
+	 * @param string $name The name of the service.
+	 *
+	 * @return void
+	 */
+	protected function resetService( $name ) {
+		//@todo: implement service reset
+	}
+
+	/**
+	 * @param $connection
+	 *
+	 * @return Registry
+	 */
+	public function addConnection( $connection ): Registry {
+		$this->connections[] = $connection;
+
+		return $this;
+	}
+
+	/**
+	 * @param string $manager
+	 *
+	 * @return Registry
+	 */
+	public function addManager( string $manager ): Registry {
+		$this->managers = $manager;
+
+		return $this;
+	}
+}

--- a/Resources/config/entity_manager.xml
+++ b/Resources/config/entity_manager.xml
@@ -4,6 +4,15 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="neo4j.entity_managers_registry" class="Neo4j\Neo4jBundle\Registry" public="true">
+            <argument type="service" id="service_container"/>
+            <argument>%neo4j.connections%</argument>
+            <argument>%neo4j.entity_managers%</argument>
+            <argument>%neo4j.entity_managers%</argument>
+            <argument type="service">%neo4j.connection.default%</argument>
+            <argument type="service">%neo4j.entity_manager.default%</argument>
+        </service>
+
         <service id="neo4j.entity_manager.abstract" class="GraphAware\Neo4j\OGM\EntityManager" abstract="true">
         </service>
     </services>

--- a/Resources/config/entity_manager.xml
+++ b/Resources/config/entity_manager.xml
@@ -9,8 +9,8 @@
             <argument>%neo4j.connections%</argument>
             <argument>%neo4j.entity_managers%</argument>
             <argument>%neo4j.entity_managers%</argument>
-            <argument type="service">%neo4j.connection.default%</argument>
-            <argument type="service">%neo4j.entity_manager.default%</argument>
+            <argument type="service" id="neo4j.connection.default"/>
+            <argument type="service" id="neo4j.entity_manager.default"/>
         </service>
 
         <service id="neo4j.entity_manager.abstract" class="GraphAware\Neo4j\OGM\EntityManager" abstract="true">


### PR DESCRIPTION
* `Registry` - service to store references of all ogm connections + all ogm entity managers. Two container params for same purpose
* Autoloader for proxy classes which are not PSR-0 compatible.
* conditional generating of proxy classes if required
* bundle's `->shutdown()` method that clears all entity managers and closes neo4j connections for better gc performance