### PR TITLE
Implementing reset method in Neo4jDataCollector

### DIFF
--- a/Collector/Neo4jDataCollector.php
+++ b/Collector/Neo4jDataCollector.php
@@ -37,6 +37,14 @@ final class Neo4jDataCollector extends DataCollector
     }
 
     /**
+     * @return void
+     */
+    public function reset()
+    {
+        $this->data = [];
+    }
+
+    /**
      * @return int
      */
     public function getQueryCount()

--- a/Collector/Neo4jDataCollector.php
+++ b/Collector/Neo4jDataCollector.php
@@ -42,6 +42,7 @@ final class Neo4jDataCollector extends DataCollector
     public function reset()
     {
         $this->data = [];
+        $this->queryLogger->reset();
     }
 
     /**

--- a/Collector/Neo4jDataCollector.php
+++ b/Collector/Neo4jDataCollector.php
@@ -36,9 +36,6 @@ final class Neo4jDataCollector extends DataCollector
         });
     }
 
-    /**
-     * @return void
-     */
     public function reset()
     {
         $this->data = [];

--- a/Collector/QueryLogger.php
+++ b/Collector/QueryLogger.php
@@ -89,10 +89,7 @@ class QueryLogger implements \Countable
             'success' => true,
         ]);
     }
-
-    /**
-     * @return void
-     */
+    
     public function reset()
     {
         $this->nbQueries = 0;

--- a/Collector/QueryLogger.php
+++ b/Collector/QueryLogger.php
@@ -91,6 +91,16 @@ class QueryLogger implements \Countable
     }
 
     /**
+     * @return void
+     */
+    public function reset()
+    {
+        $this->nbQueries = 0;
+        $this->statements = [];
+        $this->statementsHash = [];
+    }
+
+    /**
      * @param Neo4jExceptionInterface $exception
      */
     public function logException(Neo4jExceptionInterface $exception)

--- a/Collector/QueryLogger.php
+++ b/Collector/QueryLogger.php
@@ -89,7 +89,7 @@ class QueryLogger implements \Countable
             'success' => true,
         ]);
     }
-    
+
     public function reset()
     {
         $this->nbQueries = 0;


### PR DESCRIPTION
When upgrading Symfony to 3.4, the following deprecation notice is given:

```
Implementing "Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface" without the 
"reset()" method is deprecated since version 3.4 and will be unsupported in 4.0 for class 
"Neo4j\Neo4jBundle\Collector\Neo4jDataCollector"
```

I'm not sure if the resetting of the `QueryLogger` is actually needed.