### PR TITLE
Symfony5 implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,18 +28,21 @@ matrix:
         - php: 7.0
         - php: 7.1
         - php: 7.2
+        - php: 7.3
           env: COVERAGE=true TEST_COMMAND="composer test-ci" DEPENDENCIES="graphaware/neo4j-php-ogm:^1.0@rc"
 
           # Force some major versions of Symfony
-        - php: 7.2
+        - php: 7.3
           env: DEPENDENCIES="dunglas/symfony-lock:^2"
-        - php: 7.2
+        - php: 7.3
           env: DEPENDENCIES="dunglas/symfony-lock:^3"
-        - php: 7.2
+        - php: 7.3
           env: DEPENDENCIES="dunglas/symfony-lock:^4"
+        - php: 7.3
+          env: DEPENDENCIES="dunglas/symfony-lock:^5"
 
           # Latest commit to master
-        - php: 7.3
+        - php: 7.4
           env: STABILITY="dev"
 
     allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,8 @@ matrix:
           # Test with lowest dependencies
         - php: 7.2
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak"
-        - php: 7.0
-          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak"
 
           # Test the latest stable release
-        - php: 7.0
-        - php: 7.1
         - php: 7.2
         - php: 7.3
           env: COVERAGE=true TEST_COMMAND="composer test-ci" DEPENDENCIES="graphaware/neo4j-php-ogm:^1.0@rc"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,7 @@ cache:
 env:
     global:
         - TEST_COMMAND="composer test"
-        - SYMFONY_PHPUNIT_VERSION="6.5"
-
-branches:
-    except:
-        - /^analysis-.*$/
+        - SYMFONY_PHPUNIT_VERSION="8.5"
 
 matrix:
     fast_finish: true
@@ -25,13 +21,9 @@ matrix:
           # Test the latest stable release
         - php: 7.2
         - php: 7.3
-          env: COVERAGE=true TEST_COMMAND="composer test-ci" DEPENDENCIES="graphaware/neo4j-php-ogm:^1.0@rc"
+          env: COVERAGE=true TEST_COMMAND="composer test-ci" DEPENDENCIES="longitude-one/neo4j-php-ogm:^1.0@rc"
 
           # Force maintained versions of Symfony
-        - php: 7.3
-          env: SYMFONY_REQUIRE="2.8.*" #allowed to fail.
-        - php: 7.3
-          env: SYMFONY_REQUIRE="3.4.*"
         - php: 7.3
           env: SYMFONY_REQUIRE="4.4.*"
         - php: 7.3
@@ -46,10 +38,8 @@ matrix:
           env: STABILITY="dev" #allowed to fail.
 
     allow_failures:
-          # Dev-master is allowed to fail.
+        # Dev-master is allowed to fail.
         - env: STABILITY="dev"
-        - php: 7.3
-          env: SYMFONY_REQUIRE="2.8.*"
 
 before_install:
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi
@@ -57,8 +47,6 @@ before_install:
     - if ! [ -z "$DEPENDENCIES" ]; then composer require --no-update ${DEPENDENCIES}; fi;
 
 install:
-    # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
-    - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --quiet; fi
     - composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
     - vendor/bin/simple-phpunit install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,23 +31,29 @@ matrix:
         - php: 7.3
           env: COVERAGE=true TEST_COMMAND="composer test-ci" DEPENDENCIES="graphaware/neo4j-php-ogm:^1.0@rc"
 
-          # Force some major versions of Symfony
+          # Force maintained versions of Symfony
         - php: 7.3
-          env: DEPENDENCIES="dunglas/symfony-lock:^2"
+          env: SYMFONY_REQUIRE="2.8.*" #allowed to fail.
         - php: 7.3
-          env: DEPENDENCIES="dunglas/symfony-lock:^3"
+          env: SYMFONY_REQUIRE="3.4.*"
         - php: 7.3
-          env: DEPENDENCIES="dunglas/symfony-lock:^4"
+          env: SYMFONY_REQUIRE="4.4.*"
         - php: 7.3
-          env: DEPENDENCIES="dunglas/symfony-lock:^5"
+          env: SYMFONY_REQUIRE="5.0.*"
+        - php: 7.3
+          env: SYMFONY_REQUIRE="5.1.*"
+        - php: 7.4
+          env: SYMFONY_REQUIRE="5.1.*"
 
           # Latest commit to master
         - php: 7.4
-          env: STABILITY="dev"
+          env: STABILITY="dev" #allowed to fail.
 
     allow_failures:
           # Dev-master is allowed to fail.
         - env: STABILITY="dev"
+        - php: 7.3
+          env: SYMFONY_REQUIRE="2.8.*"
 
 before_install:
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi

--- a/Tests/Functional/app/config/framework.yml
+++ b/Tests/Functional/app/config/framework.yml
@@ -8,4 +8,5 @@ framework:
     validation:
         enabled: false
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/config/routing.yml"
+        utf8: true

--- a/Tests/Unit/DependencyInjection/Neo4jExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/Neo4jExtensionTest.php
@@ -10,7 +10,7 @@ use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
  */
 class Neo4jExtensionTest extends AbstractExtensionTestCase
 {
-    protected function getMinimalConfiguration()
+    protected function getMinimalConfiguration(): array
     {
         $this->setParameter('kernel.cache_dir', 'foo');
 
@@ -41,7 +41,7 @@ class Neo4jExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderNotHasService('neo4j.collector.debug_collector');
     }
 
-    protected function getContainerExtensions()
+    protected function getContainerExtensions(): array
     {
         return [
             new Neo4jExtension(),

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "graphaware/neo4j-bolt": "^1.6",
         "graphaware/neo4j-php-client": "^4.6.4",
         "symfony/dependency-injection": " ^2.8.3 || ^3.0.3 || ^4.0 || ^5.0",
+        "symfony/flex": "^1.8",
         "symfony/framework-bundle": "^2.8.32 || ^3.0 || ^4.0 || ^5.0",
         "symfony/http-kernel": "^2.8 || ^3.0 || ^4.0 || ^5.0",
         "twig/twig": "^1.18 || ^2.0"

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     ],
     "require": {
         "php": "^7.2",
+        "ongitude-one/neo4j-bolt": "^1.0",
         "longitude-one/neo4j-php-client": "^1.0",
         "symfony/dependency-injection": "^4.4 || ^5.0",
         "symfony/flex": "^1.8",

--- a/composer.json
+++ b/composer.json
@@ -15,20 +15,20 @@
         }
     ],
     "require": {
-        "php": "^7.0",
-        "graphaware/neo4j-php-client": "^4.6.4",
-        "symfony/dependency-injection": " ^2.8.3 || ^3.0.3 || ^4.0 || ^5.0",
+        "php": "^7.2",
+        "longitude-one/neo4j-php-client": "^1.0",
+        "symfony/dependency-injection": "^4.4 || ^5.0",
         "symfony/flex": "^1.8",
-        "symfony/framework-bundle": "^2.8.32 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/http-kernel": "^2.8 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/framework-bundle": "^4.4 || ^5.0",
+        "symfony/http-kernel": "^4.4 || ^5.0",
         "twig/twig": "^1.18 || ^2.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^3.4.19|^4.0",
+        "symfony/phpunit-bridge": "^4.4 || ^5.0",
         "matthiasnoback/symfony-dependency-injection-test": "^2.3"
     },
     "suggest": {
-        "graphaware/neo4j-php-ogm": "To have EntityManager support"
+        "longitude-one/neo4j-php-ogm": "To have EntityManager support"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         "php": "^7.0",
         "graphaware/neo4j-bolt": "^1.6",
         "graphaware/neo4j-php-client": "^4.6.4",
-        "symfony/dependency-injection": " ^2.8.3 || ^3.0.3 || ^4.0",
-        "symfony/framework-bundle": "^2.8.32 || ^3.0 || ^4.0",
-        "symfony/http-kernel": "^2.8 || ^3.0 || ^4.0",
+        "symfony/dependency-injection": " ^2.8.3 || ^3.0.3 || ^4.0 || ^5.0",
+        "symfony/framework-bundle": "^2.8.32 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/http-kernel": "^2.8 || ^3.0 || ^4.0 || ^5.0",
         "twig/twig": "^1.18 || ^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "ongitude-one/neo4j-bolt": "^1.0",
+        "longitude-one/neo4j-bolt": "^1.0",
         "longitude-one/neo4j-php-client": "^1.0",
         "symfony/dependency-injection": "^4.4 || ^5.0",
         "symfony/flex": "^1.8",
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^4.4 || ^5.0",
-        "matthiasnoback/symfony-dependency-injection-test": "^2.3"
+        "matthiasnoback/symfony-dependency-injection-test": "^4.1"
     },
     "suggest": {
         "longitude-one/neo4j-php-ogm": "To have EntityManager support"
@@ -40,7 +40,7 @@
         "sort-packages": true
     },
     "scripts": {
-        "test": "vendor/bin/simple-phpunit",
-        "test-ci": "vendor/bin/simple-phpunit --coverage-text --coverage-clover=build/coverage.xml"
+        "test": "simple-phpunit",
+        "test-ci": "simple-phpunit --coverage-text --coverage-clover=build/coverage.xml"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     ],
     "require": {
         "php": "^7.0",
-        "graphaware/neo4j-bolt": "^1.6",
         "graphaware/neo4j-php-client": "^4.6.4",
         "symfony/dependency-injection": " ^2.8.3 || ^3.0.3 || ^4.0 || ^5.0",
         "symfony/flex": "^1.8",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,10 @@
         </testsuite>
     </testsuites>
 
+    <php>
+        <server name="SYMFONY_PHPUNIT_VERSION" value="6.5" />
+    </php>
+
     <filter>
         <whitelist>
             <directory>./</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="./vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         syntaxCheck="true">
+<phpunit bootstrap="./vendor/autoload.php" colors="true"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/bin/.phpunit/phpunit-8.5-0/phpunit.xsd">
     <testsuites>
         <testsuite name="Unit tests">
             <directory suffix="Test.php">./Tests/Unit</directory>
@@ -16,7 +13,8 @@
     </testsuites>
 
     <php>
-        <server name="SYMFONY_PHPUNIT_VERSION" value="6.5" />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="8.5" />
+        <server name="KERNEL_DIR" value="./Tests/Resources/app" />
     </php>
 
     <filter>
@@ -29,8 +27,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <php>
-        <server name="KERNEL_DIR" value="./Tests/Resources/app" />
-    </php>
 </phpunit>


### PR DESCRIPTION
This PR is fixing  #69 and is now updated for symfony 5 :/

Because [graphaware packages are no more maintained](https://github.com/graphaware/neo4j-php-client/) and their repositories were archived, I replaced graphaware/neo4j-* by longitude-one/neo4j-* packages. Be careful, if this package works with symfony 4.4 and symfony 5.0, it doesn't work anymore with symfony 2.8 nor symfony 3.4. So, you should create a new major version.

The longitude-one packages are only compatible with Neo4j ^3.0 package. Like GraphAware packages they are not compatible with Neo4j 4.0+ nor 4.1+ (not yet).

Jobs done:
* composer updated
* requiring longitude-one/neo4j-* instead of graphaware/neo4j-* packages
* phpunit.xml.dist updated to force the phpunit 8.5
* Fixing framework.yml
* travis updated to add test on php7.4 and symfony5 and to remove symfony2, symfony3, php5.6, php7.0, php7.1
* dunglas/symfony-lock replaced by symfony/flex in the `travis.yml` file
